### PR TITLE
Absolute to relative symlinks

### DIFF
--- a/champlain-problem-library/ComputingMath/Linear-Equations
+++ b/champlain-problem-library/ComputingMath/Linear-Equations
@@ -1,1 +1,1 @@
-/opt/webwork/libraries/champlain-problem-library/LinearAlgebra/Systems-Linear-Equations/
+../LinearAlgebra/Systems-Linear-Equations

--- a/champlain-problem-library/ComputingMath/Matrices
+++ b/champlain-problem-library/ComputingMath/Matrices
@@ -1,1 +1,1 @@
-/opt/webwork/libraries/champlain-problem-library/LinearAlgebra/Matrices
+../LinearAlgebra/Matrices

--- a/champlain-problem-library/ComputingMath/Matrix-Inverse
+++ b/champlain-problem-library/ComputingMath/Matrix-Inverse
@@ -1,1 +1,1 @@
-/opt/webwork/libraries/champlain-problem-library/LinearAlgebra/Matrix-Inverse
+../LinearAlgebra/Matrix-Inverse


### PR DESCRIPTION
Absolute symlinks in the CPL are replaced by relative links (on Windows command line).
Fixes #16 