### PR TITLE
fix typos "Lorentz" -> "Lorenz"

### DIFF
--- a/champlain-problem-library/Calculus/Integrals-Economics-Applications/lorentzcurve1.pg
+++ b/champlain-problem-library/Calculus/Integrals-Economics-Applications/lorentzcurve1.pg
@@ -1,5 +1,5 @@
 # DESCRIPTION
-# Find a power function to model a Lorentz curve with a given Gini index
+# Find a power function to model a Lorenz curve with a given Gini index
 # WeBWorK problem written by Charles Fortin, 
 # <cfortin(at)champlaincollege.qc.ca(dot)ca>
 # ENDDESCRIPTION
@@ -36,7 +36,7 @@ TEXT(beginproblem());
 Context()->texStrings;
 BEGIN_TEXT
 Suppose a country has a coefficient of inequality (Gini index) of \($gini\) and that the 
-Lorentz curve for this country is of the form \(y=f(x)=x^p\), where p is a constant.
+Lorenz curve for this country is of the form \(y=f(x)=x^p\), where p is a constant.
 $BR
 (a) The value of p is \{ ans_rule(10) \}
 $BR

--- a/champlain-problem-library/Calculus/Integrals-Economics-Applications/lorentzcurve2.pg
+++ b/champlain-problem-library/Calculus/Integrals-Economics-Applications/lorentzcurve2.pg
@@ -1,6 +1,6 @@
 # DESCRIPTION
 # Find a linear combination of a linear and a power function 
-# to model a Lorentz curve given a Gini index
+# to model a Lorenz curve given a Gini index
 # WeBWorK problem written by Charles Fortin, 
 # <cfortin(at)champlaincollege.qc.ca(dot)ca>
 # ENDDESCRIPTION
@@ -39,7 +39,7 @@ TEXT(beginproblem());
 Context()->texStrings;
 BEGIN_TEXT
 Suppose a country has a coefficient of inequality (Gini index) of \($gini\) and that the 
-Lorentz curve for this country is of the form \(y=f(x)=$a x + $b x^p\), where p is a constant.
+Lorenz curve for this country is of the form \(y=f(x)=$a x + $b x^p\), where p is a constant.
 $BR
 (a) The value of p is \{ ans_rule(10) \}
 $BR

--- a/champlain-problem-library/Calculus/Integrals-Economics-Applications/tan7ed6.7.22.pg
+++ b/champlain-problem-library/Calculus/Integrals-Economics-Applications/tan7ed6.7.22.pg
@@ -1,11 +1,11 @@
 # DESCRIPTION
 # Application of integration, business/economics context.
-# Find the coefficient of inequality (Gini index) of a given Lorentz curve
+# Find the coefficient of inequality (Gini index) of a given Lorenz curve
 # describing the income distribution of a certain population.
 # M.Titcombe 10/21/2009
 # ENDDESCRIPTION
 
-## KEYWORDS ('calculus','integrals','economics','lorentz curves')
+## KEYWORDS ('calculus','integrals','economics','lorenz curves')
 
 ## DBsubject('Calculus')
 ## DBchapter('Integration')
@@ -30,11 +30,11 @@ $a1 = $c1 - $b1;
 TEXT(beginproblem());
 Context()->texStrings;
 BEGIN_TEXT
-The Lorentz curve for a certain country's income distribution is described by the function
+The Lorenz curve for a certain country's income distribution is described by the function
 \[ f(x) = \frac{$a1}{$c1}x^2 + \frac{$b1}{$c1}x \]
-Compute the coefficient of inequality for the given Lorentz curve.
+Compute the coefficient of inequality for the given Lorenz curve.
 $PAR
-The coefficient of inequality, or ${BBOLD}Gini index$EBOLD, of a Lorentz curve is
+The coefficient of inequality, or ${BBOLD}Gini index$EBOLD, of a Lorenz curve is
 \(
    L = 2\int_0^1 [x - f(x)]dx
 \).


### PR DESCRIPTION
Lorenz curves are named after Max Otto Lorenz (1876-1959),
see https://en.wikipedia.org/wiki/Max_O._Lorenz

Since some of the files might already be in use, the incorrect filenames
were not changed, just the content.