### PR TITLE
Replace bare ^ by ${CARET} in two problems

### DIFF
--- a/Course-Templates/model201-016/set03_LinearEquations/IsolateVariableIII.pg
+++ b/Course-Templates/model201-016/set03_LinearEquations/IsolateVariableIII.pg
@@ -49,7 +49,7 @@ $BR
 \( $var[$n] = \) \{ans_rule(15) \}
 $BR
 $BR
-Note: Recall \( t^2 \) can be written as t^2.
+Note: Recall \( t^2 \) can be written as t${CARET}2.
 END_TEXT
 
 ######################################

--- a/Course-Templates/model201-016/set09_Radicals/SumLikeRadicals.pg
+++ b/Course-Templates/model201-016/set09_Radicals/SumLikeRadicals.pg
@@ -64,7 +64,7 @@ $BR
 \{ AnswerFormatHelp("formulas") \}
 $BR
 $BR
-Note: You can enter a cube root as a fractional power in this problem. For example, you could write \(\sqrt[3]{x}\) as x^(1/3).
+Note: You can enter a cube root as a fractional power in this problem. For example, you could write \(\sqrt[3]{x}\) as x${CARET}(1/3).
 END_TEXT
 Context()->normalStrings;
 


### PR DESCRIPTION
Hardcopy (TeX) chokes on '^' in plain problem text.
Best practice is to use ${CARET} which is replaced properly in both
tex mode and in screen mode.  Even better is to use PGML.