### PR TITLE
Add pointers to CPL pg code for moved linear algebra problems

### DIFF
--- a/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/Anton_Linealgebra_2_30.pg
+++ b/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/Anton_Linealgebra_2_30.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_Linealgebra_2_30.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_Linealgebra_2_30.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/Anton_linearalgebra_1-2-supp-34.pg
+++ b/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/Anton_linearalgebra_1-2-supp-34.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_linearalgebra_1-2-supp-34.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_linearalgebra_1-2-supp-34.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/cfortin_cramer1.pg
+++ b/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/cfortin_cramer1.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer1.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer1.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/cfortin_cramer2.pg
+++ b/Course-Templates/model201-105/setDeterminants_bycofactor_byelimination/cfortin_cramer2.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer2.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer2.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/Anton_Linealgebra_2_30.pg
+++ b/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/Anton_Linealgebra_2_30.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_Linealgebra_2_30.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_Linealgebra_2_30.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/Anton_linearalgebra_1-2-supp-34.pg
+++ b/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/Anton_linearalgebra_1-2-supp-34.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_linearalgebra_1-2-supp-34.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11Anton_linearalgebra_1-2-supp-34.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/cfortin_cramer1.pg
+++ b/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/cfortin_cramer1.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer1.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer1.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')

--- a/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/cfortin_cramer2.pg
+++ b/Course-Templates/model201-NYC/setDeterminants_bycofactor_byelimination/cfortin_cramer2.pg
@@ -1,0 +1,17 @@
+# This file is just a pointer to the file
+#
+# champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer2.pg
+# 
+# You may want to change your problem set to use that problem
+# directly, especially if you want to make a copy of the problem
+# for modification.
+
+DOCUMENT();
+includePGproblem("champlainLibrary/LinearAlgebra/Determinants-Computing/CF11cfortin_cramer2.pg");
+ENDDOCUMENT();
+
+## These tags keep this problem from being added to the NPL database
+##
+## DBsubject('ZZZ-Inserted Text')
+## DBchapter('ZZZ-Inserted Text')
+## DBsection('ZZZ-Inserted Text')


### PR DESCRIPTION
As part of a bug squash 2022/03/16, commit b2198cff4cdc26a3afe43cd37027e0f4208e67ee
* Fixed a bug
* pointed assignments in Model201-105 and Model201-NYC at the canonical code in the CPL
* deleted the (now) redundant pg code in Model201-105 and Model201-NYC

This works fine going forward, but would break any saved set defs
that pointed to the old locations of the pg code.

This just adds pointers from the old locations in Model201-105 and Model201-NYC
to the canonical location in the CPL so saved set defs still work,
but there is only one pg file to maintain.