### PR TITLE
Diagnostic quiz fixes

### DIFF
--- a/Diagnostic-Quiz-Questions/Calculus-1/setQuiz_3_Properties_of_Limits.def
+++ b/Diagnostic-Quiz-Questions/Calculus-1/setQuiz_3_Properties_of_Limits.def
@@ -5,7 +5,7 @@ dueDate           = 12/31/2022 at 11:59pm EST
 answerDate        = 12/31/2022 at 11:59pm EST
 enableReducedScoring = N
 paperHeaderFile   = defaultHeader
-screenHeaderFile  = 
+screenHeaderFile  = defaultHeader
 attemptsPerVersion  = 0
 timeInterval        = 0
 versionsPerInterval = 0
@@ -20,10 +20,10 @@ description       = This quiz has 5 questions to complete in 15 minutes. Try the
 restrictProbProgression = 0
 emailInstructor   = 0
 
-problemListV2 
+problemListV2
 problem_start
 problem_id = 1
-source_file = group:topic-limits-theory
+source_file = group:topic-limits-laws-properties
 value = 1
 max_attempts = -1
 showMeAnother = -1
@@ -33,7 +33,7 @@ att_to_open_children = 0
 problem_end
 problem_start
 problem_id = 2
-source_file = group:topic-limits-theory
+source_file = group:topic-limits-laws-properties
 value = 1
 max_attempts = -1
 showMeAnother = -1
@@ -43,7 +43,7 @@ att_to_open_children = 0
 problem_end
 problem_start
 problem_id = 3
-source_file = group:topic-limits-theory
+source_file = group:topic-limits-laws-properties
 value = 1
 max_attempts = -1
 showMeAnother = -1
@@ -53,7 +53,7 @@ att_to_open_children = 0
 problem_end
 problem_start
 problem_id = 4
-source_file = group:topic-limits-theory
+source_file = group:topic-limits-laws-properties
 value = 1
 max_attempts = -1
 showMeAnother = -1
@@ -63,7 +63,7 @@ att_to_open_children = 0
 problem_end
 problem_start
 problem_id = 5
-source_file = group:topic-limits-theory
+source_file = group:topic-limits-laws-properties
 value = 1
 max_attempts = -1
 showMeAnother = -1

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-derivatives-limit-definition/deriv-limit-form-mc2.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-derivatives-limit-definition/deriv-limit-form-mc2.pg
@@ -19,9 +19,6 @@
 # @randc : array of correct choice(s) to display
 # @randi : array of incorrect choice(s) to display
 
-
-
-
 DOCUMENT();
   loadMacros(
     "PGstandard.pl",
@@ -46,39 +43,29 @@ $numc = 1;
 if ($showc == 0){$numc = 0;}
 
 # Set parameters
-# Choose three different numbers (non-zero)
+# Choose two different numbers (non-zero)
 @vals = 2..11;
 @slice = NchooseK(scalar(@vals),3);
 @param = @vals[@slice];
 $a = $param[0];  # a positive
 $b = $param[1]*random(-1,1,2);
-#$c = $param[2]*random(-1,1,2);
 
 $ma = -1*$a;
 $mb = -1*$b;
-#$mc = -1*$c;
 $absa = abs($a);
 $absb = abs($b);
-#$absc = abs($c);
 $twoa = 2*$a;
 $mtwoa = -2*$a;
 
-$numer = "f($a + h) - $b";
-if ($b < 0){
-    $numer = "f($a + h) + $absb";
-    }
+#$numer = "f($a + h) - $b";
+#if ($b < 0){
+#    $numer = "f($a + h) + $absb";
+#    }
 $fun = Compute("$b - $a x^2")->reduce()->TeX;
-$diff0 = Compute("$b - $a x^2 - $twoa x h - $a h^2")->reduce()->TeX; #corr +---
-$diff1 = Compute("$b - $a x^2 - $twoa x h + $a h^2")->reduce()->TeX; # +--+
-$diff2 = Compute("$b - $a x^2 + $twoa x h - $a h^2")->reduce()->TeX; # +-+-
-$diff3 = Compute("$b - $a x^2 + $twoa x h + $a h^2")->reduce()->TeX; # +-++
-$diff4 = Compute("$b + $a x^2 - $twoa x h - $a h^2")->reduce()->TeX; # ++--
-$diff5 = Compute("$b + $a x^2 - $twoa x h + $a h^2")->reduce()->TeX; # ++-+
-$diff6 = Compute("$b + $a x^2 + $twoa x h - $a h^2")->reduce()->TeX; # +++-
-$diff7 = Compute("$b + $a x^2 + $twoa x h + $a h^2")->reduce()->TeX; # ++++
-$diff8 = Compute("$mb - $a x^2 - $twoa x h - $a h^2")->reduce()->TeX; # ----
-$diff9 = Compute("$b - $a x^2 + $a h^2")->reduce()->TeX; # missing term -+
-$diff10 = Compute("$b - $a x^2 - $a h^2")->reduce()->TeX; # missing term --
+$diff0 = Compute("- $twoa x h - $a h^2")->reduce()->TeX; #corr --
+$diff1 = Compute("- $twoa x h + $a h^2")->reduce()->TeX; # -+
+$diff2 = Compute("$twoa x h - $a h^2")->reduce()->TeX; # +-
+$diff3 = Compute("$twoa x h + $a h^2")->reduce()->TeX; # ++
     
 # Answer arrays
 #    @allAns: array of all possible answers (at least 5: 1 correct, 4 incorrect)
@@ -87,17 +74,14 @@ $diff10 = Compute("$b - $a x^2 - $a h^2")->reduce()->TeX; # missing term --
 #                depends on something in the code)
 #    @slicei = indices of subset of incorrects
 #    @randi = random subset of incorrects (3 or 4 elements)
-@allAns = ("\( \lim\limits_{h\to 0}\dfrac{ $diff0 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff1 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff2 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff3 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff4 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff5 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff6 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff7 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff8 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff9 }{h} \)",
-            "\( \lim\limits_{h\to 0}\dfrac{ $diff10 }{h} \)",
+@allAns = ("\( \lim\limits_{h\to 0}\dfrac{ $diff0 }{h} \)", # correct, signs are --
+            "\( \lim\limits_{x\to 0}\dfrac{ $diff0 }{h} \)", # error x->0
+            "\( \lim\limits_{h\to 0}\dfrac{ $diff1 }{h} \)", # error sign -+
+            "\( \lim\limits_{x\to 0}\dfrac{ $diff1 }{h} \)", # error sign -+ and x->0
+            "\( \lim\limits_{h\to 0}\dfrac{ $diff2 }{h} \)", # error sign +-
+            "\( \lim\limits_{x\to 0}\dfrac{ $diff2 }{h} \)", # error sign +- and x->0
+            "\( \lim\limits_{h\to 0}\dfrac{ $diff3 }{h} \)", # error sign ++
+            "\( \lim\limits_{x\to 0}\dfrac{ $diff3 }{h} \)", # error sign ++ and x->0
            );
 
 $correct = $allAns[0];

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-differentials/differentials-ms1.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-differentials/differentials-ms1.pg
@@ -80,8 +80,8 @@ $errdeltay = $fa1 + $fa2;
     "\(dy =  ($fpa) \cdot ($mdx)  \)", # distractor: wrong sign of dx
     "\(dy = ($fa2) - ($fa1)  \)",  # distractor: dy instead of Deltay
     "The exact change in \(y\) is \( $dy \)", # distractor: dy instead
-    "The differential \(dy\) is \( $Deltay \)", # distractor: Deltay instead
-    "The approximate change in \(y\) is \( $Deltay \)", # distractor: Deltay 
+    "The differential \(dy\) is \( $deltay \)", # distractor: Deltay instead
+    "The approximate change in \(y\) is \( $deltay \)", # distractor: Deltay 
     "\(\Delta x = $mdx\)", # distractor: wrong sign
     );
     

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-limits-continuity-ivt/IVT-interval-ms1.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-limits-continuity-ivt/IVT-interval-ms1.pg
@@ -37,7 +37,7 @@ Context("Numeric");
 # Set parameters:
 
 do{$n = random(3, 13, 2); # n is odd to avoid possible negative solutions
-}until(n != 5); # if n = 5, x=5 is a solution and a bunch of wrong intervals are correct
+}until($n != 5); # if n = 5, x=5 is a solution and a bunch of wrong intervals are correct
 
 
 # The range contianing the intervals: 

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-limits-continuity-ivt/IVT-table-ms1.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-limits-continuity-ivt/IVT-table-ms1.pg
@@ -78,7 +78,7 @@ for($i=$ySignChange+1; $i<=5; $i++){
 @corrAns = ();
 for($i=0; $i <= $ySignChange-1; $i++){
     for($j=$ySignChange; $j <= 5; $j++){
-        push(@corrAns, "\([$yValues[$i], $yValues[$j] ]\)" );
+        push(@corrAns, "\([$xValues[$i], $xValues[$j] ]\)" );
     }
 }
 

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-related-rates/WordProblem-mc1.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-related-rates/WordProblem-mc1.pg
@@ -111,16 +111,16 @@ $chooseQandA = random(0,4,1);
 );
 
 if($chooseQandA == 0){
-    $priceInc = "$BBOLD the price of tyres is increasing by $dpdtValue dollars per week $EBOLD";
+    $priceInc = "the price of tyres is $BBOLD increasing $EBOLD by $dpdtValue dollars per week";
 }
 elsif($chooseQandA == 1){
-    $demand = "BBOLD the quantity demanded weekly EBOLD";
+    $demand = "$BBOLD the quantity demanded weekly $EBOLD";
 }
 elsif($chooseQandA == 2){
-    $price = "BBOLD unit price EBOLD";
+    $price = "$BBOLD unit price $EBOLD";
 }
 elsif($chooseQandA == 3){
-    $priceInc = "$BBOLD the price of tyres is increasing by $dpdtValue dollars per week $EBOLD";
+    $priceInc = "the price of tyres is $BBOLD increasing $EBOLD by $dpdtValue dollars per week";
 }
 else{
 }

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-related-rates/WordProblem-mc2.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-related-rates/WordProblem-mc2.pg
@@ -117,7 +117,7 @@ $chooseQandA = random(0,4,1);
 );
 
 if($chooseQandA == 0){
-    $priceInc = "$BBOLD the price of headphones is dropping by $dpdtValue dollars per set of headphones per week $EBOLD";
+    $priceInc = "the price of headphones is $BBOLD dropping $EBOLD by $dpdtValue dollars per set of headphones per week";
 }
 elsif($chooseQandA == 1){
     $demand = "$BBOLD demand equation $EBOLD";
@@ -126,7 +126,7 @@ elsif($chooseQandA == 2){
     $price = "$BBOLD unit price $EBOLD";
 }
 elsif($chooseQandA == 3){
-    $priceInc = "$BBOLD the price of headphones is dropping by $dpdtValue dollars per set of headphones per week $EBOLD";
+    $priceInc = "the price of headphones is $BBOLD dropping $EBOLD by $dpdtValue dollars per set of headphones per week";
 }
 else{
 }

--- a/Diagnostic-Quiz-Questions/Calculus-1/settopic-related-rates/related-rates-word-mc1.pg
+++ b/Diagnostic-Quiz-Questions/Calculus-1/settopic-related-rates/related-rates-word-mc1.pg
@@ -116,7 +116,7 @@ END_TIKZ
 #########################################################
 
 BEGIN_PGML
-A hemispherical basin of diameter [`[$diam]`] centimetres is filling up with water at a rate of [`[$dVdtdisp]`] litres per minute. Consider the moment when the basin is [$howfull] full. At what rate is the water rising in the basin at that moment? 
+A hemispherical basin of diameter [`[$diam]`] centimetres is filling up with water at a rate of [`[$dVdtdisp]`] litres per minute. Consider the moment when the basin is [$howfull] full (in terms of its height). At what rate is the water rising in the basin at that moment? 
 
 Notes: the volume of the portion of a sphere with radius [`r`] from the bottom to a height [`h`] is [` V = \pi (rh^2 - \frac{1}{3} h^3)  `]; and 1 litre equals 1000 cubic centimetres.
 

--- a/Diagnostic-Quiz-Questions/Pre-Calculus/settopic-simplifying/simplify-squareroot-ms1.pg
+++ b/Diagnostic-Quiz-Questions/Pre-Calculus/settopic-simplifying/simplify-squareroot-ms1.pg
@@ -60,7 +60,7 @@ $type = $typearray[$n];
    );
 
 # all true
-@allT = ("\( \sqrt{$x $y} = \sqrt{$x} + \sqrt{$y} \)",
+@allT = ("\( \sqrt{$x $y} = \sqrt{$x} \sqrt{$y} \)",
          "\( \sqrt{$asq $x} = $a\sqrt{$x} \)",
          "\( \sqrt{$x^2} = |$x| \)",
          "\( (\sqrt{$x})^2 = $x \)",

--- a/champlain-problem-library/Calculus/Limits-Laws-Properties/MT21polynomiallimit-tf.pg
+++ b/champlain-problem-library/Calculus/Limits-Laws-Properties/MT21polynomiallimit-tf.pg
@@ -1,0 +1,57 @@
+## DBsubject(Calculus - single variable)
+## DBchapter(Limits and continuity)
+## DBsection(Rules of limits - basic)
+## Institution(Champlain College Saint-Lambert)
+## Author(Michele Titcombe)
+## Date(2021-Feb-09)
+## MLT(LimitRules_TrueFalse)
+## Level(3)
+## Static(1)
+## TitleText1('Calculus: Early Transcendentals')
+## AuthorText1('Stewart')
+## EditionText1('5')
+## Section1('2.3')
+## Problem1('53')
+## KEYWORDS('Product','Quotient','Differentiation')
+
+DOCUMENT();
+  loadMacros(
+    "PGstandard.pl",
+    "PGML.pl",
+    "MathObjects.pl",
+    "parserRadioButtons.pl",
+    "PGcourse.pl",
+  );
+TEXT(beginproblem());
+$showPartialCorrectAnswers = 0;   # set to 0 because multiple choice
+
+Context("Numeric");
+#$a = non_zero_random(-6,6,2);
+#$b = random(1,9,1);
+#$c = non_zero_random(-5,5,1);
+
+$correct = "True";
+$radio1 = RadioButtons(
+	["True",
+	"False"],
+	"True",  # Correct answer
+	);
+
+BEGIN_PGML
+True or False?  
+If [`p`] is a polynomial, then [`\displaystyle \lim_{x \to a} p(x)=p(a)`].
+
+[@ $radio1->buttons() @]*
+END_PGML
+############################
+#  Answer evaluation
+install_problem_grader(~~&std_problem_grader);
+ANS( $radio1->cmp() );
+
+BEGIN_PGML_SOLUTION
+The answer is [$correct].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();
+
+

--- a/champlain-problem-library/Calculus/Limits-Laws-Properties/MT21rationallimit-tf.pg
+++ b/champlain-problem-library/Calculus/Limits-Laws-Properties/MT21rationallimit-tf.pg
@@ -1,0 +1,58 @@
+## DBsubject(Calculus - single variable)
+## DBchapter(Limits and continuity)
+## DBsection(Rules of limits - basic)
+## Institution(Champlain College Saint-Lambert)
+## Author(Michele Titcombe)
+## Date(2021-Feb-09)
+## MLT(LimitRules_TrueFalse)
+## Level(3)
+## Static(1)
+## TitleText1('Calculus: Early Transcendentals')
+## AuthorText1('Stewart')
+## EditionText1('5')
+## Section1('2.3')
+## Problem1('53')
+## KEYWORDS('Product','Quotient','Differentiation')
+
+DOCUMENT();
+  loadMacros(
+    "PGstandard.pl",
+    "PGML.pl",
+    "MathObjects.pl",
+    "parserRadioButtons.pl",
+    "PGcourse.pl",
+  );
+TEXT(beginproblem());
+$showPartialCorrectAnswers = 0;   # set to 0 because multiple choice
+
+Context("Numeric");
+#$a = non_zero_random(-6,6,2);
+#$b = random(1,9,1);
+#$c = non_zero_random(-5,5,1);
+
+$correct = "True";
+$radio1 = RadioButtons(
+	["True",
+	"False"],
+	$correct,  # Correct answer
+	);
+
+BEGIN_PGML
+True or False?  
+If [`f(x)`] is a rational function and  [`x=a`] is in the domain of [`f`], then [`\displaystyle\lim_{x\to a}f(x)=f(a)`]
+
+[@ $radio1->buttons() @]*
+END_PGML
+############################
+#  Answer evaluation
+install_problem_grader(~~&std_problem_grader);
+ANS( $radio1->cmp() );
+
+BEGIN_PGML_SOLUTION
+The answer is [$correct]. If [`f(x)=\frac{p(x)}{q(x)}`], for polynomials [`p`] and [`q`], then if [`x=a`] is in the domain of [`f`], [`q(a)\ne 0`] and hence
+[`\displaystyle \lim_{x\to a}f(x)=f(a)`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();
+
+


### PR DESCRIPTION
Several fixes of Calculus 1 diagnostic quiz questions:
- IVT-interval-ms1.pg
- IVT-table-ms1.pg
- WordProblem-mc1.pg
- WordProblem-mc2.pg
- related-rates-word-mc1.pg
- deriv-limit-form-mc2.pg
- differentials-ms1.pg
- Quiz_3_Properties_of_Limits.def

One fix of Pre-Calculus diagnostic quiz question:
- simplifying-square-root-ms1.pg