### PR TITLE
MT26 linear algebra SN4 add and update Leontief problems

### DIFF
--- a/champlain-problem-library/LinearAlgebra/Matrices-Applications-Leontief-Closed/MT23_Leontief_diagram.pg
+++ b/champlain-problem-library/LinearAlgebra/Matrices-Applications-Leontief-Closed/MT23_Leontief_diagram.pg
@@ -1,5 +1,7 @@
 ##DESCRIPTION
 ##  Linear Algebra: Leontief model diagram
+##  Update: M.Titcombe 2026-May: add definition a_ij to text
+##  Reference: Linear Algebra, copyright 2025 zyBooks.com, Alan Bass, Heather Berrier, Chris Chan and Ron Siu.)  
 ##ENDDESCRIPTION
 
 ##KEYWORDS('Leontief', 'input-output', 'model')
@@ -7,9 +9,14 @@
 ## DBsubject('Linear Algebra')
 ## DBchapter('Matrices')
 ## DBsection('Applications')
-## Date('2023-Nov-15')
+## Date('Update 2026-May-25, Original: 2023-Nov-15')
 ## Author('Michele Titcombe')
 ## Institution('Champlain College Saint-Lambert')
+## TitleText1(Linear Algebra)
+## EditionText1(2025)
+## AuthorText1(Bass, Berrier, Chan, Siu)
+## Section1(2.9)
+## Problem1(Participation 2.9.2)
 
 ########################################################################
 
@@ -86,7 +93,8 @@ BEGIN_PGML
 >> [@ image($graph_image, width => 400, tex_size => 600) @]* <<
 
 The diagram above represents a simple closed economy with three sectors. Fill in the entries in the corresponding input-output matrix.  
-[`A = `][_____]*{$A}
+[`A = `][_____]*{$A}  
+Note: Each entry [`a_{ij}`] gives the proportion of output produced by sector [`i`] and consumed by sector [`j`], which means that each column is represented by the arrows going out of the corresponding sector in the diagram.  
 END_PGML
 
 ############################
@@ -94,7 +102,9 @@ END_PGML
 
 
 BEGIN_PGML_SOLUTION
-Each entry [`a_{ij}`] gives the proportion of output produced by sector [`i`] and consumed by sector [`j`], which means that each column of the input-output matrix should be represented by the arrows going out of the corresponding sector. 
+Each entry [`a_{ij}`] gives the proportion of output produced by sector [`i`] and consumed by sector [`j`], which means that each column of the input-output matrix should be represented by the arrows going out of the corresponding sector.  
+Using this definition, the input-output matrix is:  
+[`A = [$A]`]
 END_PGML_SOLUTION
 
 ENDDOCUMENT();

--- a/champlain-problem-library/LinearAlgebra/Matrices-Applications-Leontief-Open/MT23_Leontief3x3.pg
+++ b/champlain-problem-library/LinearAlgebra/Matrices-Applications-Leontief-Open/MT23_Leontief3x3.pg
@@ -1,0 +1,65 @@
+## DESCRIPTION
+## Linear Algebra. Leontief input-output model
+## ENDDESCRIPTION
+
+## DBsubject('Linear Algebra')
+## DBchapter('Matrices')
+## DBsection('Determinants')
+## Date('2023')
+## Author('Michele Titcombe')
+## Institution('Champlain College Saint-Lambert')
+## TitleText1('')
+## EditionText1('')
+## AuthorText1('')
+## Section1('')
+## Problem1('')
+
+DOCUMENT();        # This should be the first executable line in the problem.
+
+loadMacros(
+    "PGstandard.pl",
+    "PGML.pl",
+    "PGcourse.pl",
+);
+
+TEXT(beginproblem());
+Context(Matrix);
+$showPartialCorrectAnswers = 1;
+
+$a11 = random(.05,.15,.5);
+$a21 = random(.25,.35,.5);
+$a31 = random(.25,.35,.5);
+$a12 = random(.50,.60,.5);
+$a22 = random(.15,.25,.5);
+$a32 = random(.10,.20,.5);
+$a13 = random(.50,.60,.5);
+$a23 = 0;
+$a33 = random(.10,.20,.5);
+$C = Matrix([
+           [$a11, $a12, $a13],
+           [$a21, $a22, $a23],
+           [$a31, $a32, $a33],
+           ]);
+$I = Matrix([[1,0,0],[0,1,0],[0,0,1]]); 
+$ImC = $I - $C;
+
+$detImC = $ImC->det;
+$ImCinv = $ImC->inverse;
+
+BEGIN_PGML
+Consider an open economy that is divided into three sectors. For each unit of output,  
+- Sector 1 requires [$a11] units from itself, [$a21] units from sector 2, and [$a31] units from sector 3.  
+- Sector 2 requires [$a22] units from itself, [$a12] units from sector 1, and [$a32] units from sector 3.  
+- Sector 3 requires [$a33] units from itself, [$a13] units from sector 1, and [$a23] units from sector 2.
+ 
+Construct the consumption matrix for this economy. Note: column [`j`] is the consumption of Sector [`j`].  
+[`C = `][____]*{$C}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Column [`j`] is the consumption of Sector [`j`].  
+By this definition, the consumption matrix is:  
+[`C = [$C]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();       # This should be the last executable line in the problem.


### PR DESCRIPTION
Add 1 problem to CPL and update 1 problem in CPL on Leontief Economic Models to be included in update of model-SN4 course templates.

Add to LinearAlgebra/Matrices-Applications-Leontief-Open:
- MT23_Leontief3x3.pg

Modify in LinearAlgebra/Matrices-Applications-Leontief-Closed:
- MT23_Leontief_diagram.pg : updated to include definition in the text and textbook reference
